### PR TITLE
mark more author tests properly

### DIFF
--- a/t/boilerplate.t
+++ b/t/boilerplate.t
@@ -4,6 +4,11 @@ use strict;
 use warnings;
 use Test::More tests => 3;
 
+if ( not $ENV{TEST_AUTHOR} ) {
+    my $msg = 'Author test.  Set $ENV{TEST_AUTHOR} to a true value to run.';
+    plan( skip_all => $msg );
+}
+
 sub not_in_file_ok {
     my ($filename, %regex) = @_;
     open( my $fh, '<', $filename )

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -2,6 +2,11 @@ use strict;
 use warnings;
 use Test::More;
 
+if ( not $ENV{TEST_AUTHOR} ) {
+    my $msg = 'Author test.  Set $ENV{TEST_AUTHOR} to a true value to run.';
+    plan( skip_all => $msg );
+}
+
 # Ensure a recent version of Test::Pod::Coverage
 my $min_tpc = 1.08;
 eval "use Test::Pod::Coverage $min_tpc";

--- a/t/pod.t
+++ b/t/pod.t
@@ -4,6 +4,11 @@ use strict;
 use warnings;
 use Test::More;
 
+if ( not $ENV{TEST_AUTHOR} ) {
+    my $msg = 'Author test.  Set $ENV{TEST_AUTHOR} to a true value to run.';
+    plan( skip_all => $msg );
+}
+
 # Ensure a recent version of Test::Pod
 my $min_tp = 1.22;
 eval "use Test::Pod $min_tp";


### PR DESCRIPTION
A number of author tests weren't marked as such and caused pointless test failures on user systems. This commit fixes that.
